### PR TITLE
Enable CI for Ocaml 4.03 and 4.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
     - OCAML_VERSION=4.02 PACKAGE=key-parsers
-    - OCAML_VERSION=latest PACKAGE=key-parsers
+    - OCAML_VERSION=4.03 PACKAGE=key-parsers
+    - OCAML_VERSION=4.04 PACKAGE=key-parsers
 os:
     - linux


### PR DESCRIPTION
According to https://github.com/ocaml/ocaml-ci-scripts/issues/110, `OCAML_VERSION=latest` is deprecated and means `4.02`.

This adds a build for 4.03 (which was what was expected with `latest`) and 4.04 that's being released.
