### PR TITLE
Refact/simplify ppx deriving tag cvclib

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 true: package(asn1-combinators), package(zarith)
 true: package(result)
-true: package(ppx_deriving), package(ppx_deriving_yojson.runtime)
+true: package(ppx_deriving), package(ppx_deriving.std), package(ppx_deriving_yojson.runtime)
 true: safe_string
 true: bin_annot
 true: debug
@@ -8,9 +8,9 @@ true: debug
 "src": include
 
 <src/*.ml>: for-pack(Key_parsers)
-<src/asn1.*>: package(ppx_deriving.std), package(ppx_deriving_yojson)
-<src/ltpa.*>: package(ppx_deriving.ord), package(ppx_deriving_yojson)
-<src/cvc.*>: package(ppx_deriving.ord), package(ppx_deriving_yojson), package(ppx_deriving.eq), package(ppx_deriving.show)
+<src/asn1.*>: package(ppx_deriving_yojson)
+<src/cvc.*>: package(ppx_deriving_yojson)
+<src/ltpa.*>: package(ppx_deriving_yojson)
 
 <tests/*>: package(oUnit)
 <tests/*>: package(hex)

--- a/src/cvc.ml
+++ b/src/cvc.ml
@@ -1,36 +1,3 @@
-(*module RSA :
-sig
-  module Public :
-  sig
-    type t =
-      { n: Z.t
-      ; e: Z.t
-      }
-      [@@deriving ord,yojson,eq,show]
-
-    val decode : Cstruct.t -> (t, string) Result.result
-  end
-end
-
-module ECDSA :
-sig
-  module Public :
-  sig
-    type t =
-      { modulus : Z.t
-      ; coefficient_a : Z.t
-      ; coefficient_b : Z.t
-      ; base_point_g : Z.t
-      ; base_point_r_order : Z.t
-      ; public_point_y : Z.t
-      ; cofactor_f : Z.t
-      }
-      [@@deriving ord,yojson,eq,show]
-
-    val decode : Cstruct.t -> (t, string) Result.result
-  end
-end*)
-
 let try_with_asn f = try Result.Ok (f ()) with Asn.Parse_error s -> Result.Error s
 let raise_asn f = match f () with Result.Ok x -> x | Result.Error s -> Asn.parse_error s
 
@@ -295,9 +262,10 @@ struct
         | Ok (`RSA (n, e)) ->
             Ok {n; e}
         | Ok (`ECDSA _)
-        | Ok (`RSA _)
         | Ok `UNKNOWN ->
             Error "CVC: Algorithm OID and parameters do not match."
+        | Error _ as err -> (* aliasing to avoid unnecessary allocation *)
+            err
   end
 end
 
@@ -338,9 +306,10 @@ struct
               ; cofactor_f
               }
         | Ok (`RSA _)
-        | Ok (`ECDSA _)
         | Ok `UNKNOWN ->
             Error "CVC: Algorithm OID and parameters do not match."
+        | Error _ as err -> (* aliasing to avoid unnecessary allocation *)
+            err
   end
 end
 

--- a/src/cvc.ml
+++ b/src/cvc.ml
@@ -264,7 +264,7 @@ struct
         | Ok (`ECDSA _)
         | Ok `UNKNOWN ->
             Error "CVC: Algorithm OID and parameters do not match."
-        | Error _ as err -> (* aliasing to avoid unnecessary allocation *)
+        | Error _ as err ->
             err
   end
 end
@@ -308,7 +308,7 @@ struct
         | Ok (`RSA _)
         | Ok `UNKNOWN ->
             Error "CVC: Algorithm OID and parameters do not match."
-        | Error _ as err -> (* aliasing to avoid unnecessary allocation *)
+        | Error _ as err ->
             err
   end
 end


### PR DESCRIPTION
This PR simplifies the `_tags` file and fixes a few warnings triggered by the CVC code as mentioned in #13 
