### PR TITLE
Add missing dependency to Cstruct

### DIFF
--- a/opam
+++ b/opam
@@ -23,5 +23,6 @@ depends: [
   "result" {>= "1.2"}
   "topkg" {build}
   "ppx_bin_prot"
+  "cstruct" {>= "1.6.0"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
The dependency is implicit through `asn1-combinators`, but can cause the
wrong version of `cstruct` to be installed. In particular, it uses
`Cstruct.compare` which was introduced in version 1.6.0.

Thanks!