### PR TITLE
Compatibility with ppx_bin_prot 0.9.0

### DIFF
--- a/_tags
+++ b/_tags
@@ -11,6 +11,7 @@ true: debug
 <src/kp_asn1.*>: package(ppx_deriving_yojson), package(ppx_bin_prot)
 <src/kp_cvc.*>: package(ppx_deriving_yojson), package(ppx_bin_prot)
 <src/kp_ltpa.*>: package(ppx_deriving_yojson), package(ppx_bin_prot)
+<src/kp_derivable.*>: package(ppx_deriving_yojson), package(ppx_bin_prot)
 <src/key_parsers.mli>: package(ppx_deriving_yojson), package(ppx_bin_prot)
 
 <tests/*>: package(oUnit)

--- a/src/key_parsers.mllib
+++ b/src/key_parsers.mllib
@@ -1,4 +1,5 @@
 Kp_asn1
 Kp_ltpa
 Kp_cvc
+Kp_derivable
 Key_parsers

--- a/src/kp_cvc.ml
+++ b/src/kp_cvc.ml
@@ -1,81 +1,5 @@
 open Bin_prot.Std
 
-let try_with_asn f = try Result.Ok (f ()) with Asn.Parse_error s -> Result.Error s
-let raise_asn f = match f () with Result.Ok x -> x | Result.Error s -> Asn.parse_error s
-
-let pp_of_to_string to_string fmt x =
-  Format.pp_print_string fmt (to_string x)
-
-module Asn = struct
-  include (Asn : module type of Asn with module OID := Asn.OID and type 'a t = 'a Asn.t)
-
-  module OID = struct
-    include Asn.OID
-    let pp = pp_of_to_string to_string
-    let compare a b =
-      String.compare (to_string a) (to_string b)
-    let equal a b = compare a b = 0
-
-    let of_yojson = function
-      | `String s -> Result.Ok (Asn.OID.of_string s)
-      | _ -> Result.Error "Cannot convert this json value to Asn.OID.t"
-
-    let to_yojson oid =
-      `String (Asn.OID.to_string oid)
-
-    let bin_writer_t = Bin_prot.Type_class.cnv_writer to_string bin_writer_string
-    let bin_reader_t = Bin_prot.Type_class.cnv_reader of_string bin_reader_string
-    let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-    let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-    let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-    let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-  end
-end
-
-module Z = struct
-  include Z
-  let pp = pp_of_to_string to_string
-
-  let of_yojson = function
-    | `String s -> Result.Ok (Z.of_string s)
-    | _ -> Result.Error "Cannot convert this json value to Z.t"
-
-  let to_yojson z =
-    `String (Z.to_string z)
-
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer to_bits bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader of_bits bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-end
-
-module Cstruct = struct
-  include Cstruct
-
-  let to_hex_string cs =
-    let buf = Buffer.create 0 in
-    hexdump_to_buffer buf cs;
-    Buffer.contents buf
-
-  let pp = pp_of_to_string to_hex_string
-
-  let to_yojson cs =
-    `String (to_string cs)
-
-  let of_yojson = function
-    | `String s -> Result.Ok (of_string s)
-    | _ -> Result.Error "Cannot convert this json value to Cstruct.t"
-
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer to_string bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader of_string bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-end
-
 let base_rsa_oid = Asn.OID.of_string "0.4.0.127.0.7.2.2.2.1"
 let base_ecdsa_oid = Asn.OID.of_string "0.4.0.127.0.7.2.2.2.2"
 
@@ -314,8 +238,8 @@ struct
   module Public =
   struct
     type t = {
-      n: Z.t;
-      e: Z.t;
+      n: Kp_derivable.Z.t;
+      e: Kp_derivable.Z.t;
     }
     [@@deriving ord,eq,yojson,eq,show,bin_io]
 
@@ -337,13 +261,13 @@ struct
   module Public =
   struct
     type t =
-      { modulus : Z.t
-      ; coefficient_a : Cstruct.t
-      ; coefficient_b : Cstruct.t
-      ; base_point_g : Cstruct.t
-      ; base_point_r_order : Z.t
-      ; public_point_y : Cstruct.t
-      ; cofactor_f : Z.t
+      { modulus : Kp_derivable.Z.t
+      ; coefficient_a : Kp_derivable.Cstruct.t
+      ; coefficient_b : Kp_derivable.Cstruct.t
+      ; base_point_g : Kp_derivable.Cstruct.t
+      ; base_point_r_order : Kp_derivable.Z.t
+      ; public_point_y : Kp_derivable.Cstruct.t
+      ; cofactor_f : Kp_derivable.Z.t
       }
       [@@deriving ord,eq,yojson,eq,show,bin_io]
 

--- a/src/kp_derivable.ml
+++ b/src/kp_derivable.ml
@@ -1,0 +1,79 @@
+open Bin_prot.Std
+
+let pp_of_to_string to_string fmt x =
+  Format.pp_print_string fmt (to_string x)
+
+module Z = struct
+  type t = Z.t
+  [@@deriving eq,ord]
+
+  let show = Z.to_string
+  let pp = pp_of_to_string show
+
+  let of_yojson = function
+    | `String s -> Result.Ok (Z.of_string s)
+    | _ -> Result.Error "Cannot convert this json value to Z.t"
+
+  let to_yojson z =
+    `String (Z.to_string z)
+
+  let bin_writer_t = Bin_prot.Type_class.cnv_writer Z.to_bits bin_writer_string
+  let bin_reader_t = Bin_prot.Type_class.cnv_reader Z.of_bits bin_reader_string
+  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
+  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
+  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
+  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
+  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+end
+
+module Cstruct = struct
+  type t = Cstruct.t
+  [@@deriving eq,ord]
+
+  let to_hex_string cs =
+    let buf = Buffer.create 0 in
+    Cstruct.hexdump_to_buffer buf cs;
+    Buffer.contents buf
+
+  let show = to_hex_string
+  let pp = pp_of_to_string show
+
+  let to_yojson cs =
+    `String (Cstruct.to_string cs)
+
+  let of_yojson = function
+    | `String s -> Result.Ok (Cstruct.of_string s)
+    | _ -> Result.Error "Cannot convert this json value to Cstruct.t"
+
+  let bin_writer_t = Bin_prot.Type_class.cnv_writer Cstruct.to_string bin_writer_string
+  let bin_reader_t = Bin_prot.Type_class.cnv_reader Cstruct.of_string bin_reader_string
+  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
+  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
+  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
+  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
+  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+end
+
+module Asn_OID = struct
+  type t = Asn.OID.t
+  let show = Asn.OID.to_string
+  let pp = pp_of_to_string show
+  let compare a b =
+    String.compare (show a) (show b)
+  let equal a b = compare a b = 0
+
+  let of_yojson = function
+    | `String s -> Result.Ok (Asn.OID.of_string s)
+    | _ -> Result.Error "Cannot convert this json value to Asn.OID.t"
+
+  let to_yojson oid =
+    `String (Asn.OID.to_string oid)
+
+  let bin_writer_t = Bin_prot.Type_class.cnv_writer Asn.OID.to_string bin_writer_string
+  let bin_reader_t = Bin_prot.Type_class.cnv_reader Asn.OID.of_string bin_reader_string
+  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
+  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
+  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
+  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
+  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+end

--- a/src/kp_derivable.ml
+++ b/src/kp_derivable.ml
@@ -3,6 +3,11 @@ open Bin_prot.Std
 let pp_of_to_string to_string fmt x =
   Format.pp_print_string fmt (to_string x)
 
+module Bin_string = struct
+  type t = string
+  [@@deriving bin_io]
+end
+
 module Z = struct
   type t = Z.t
   [@@deriving eq,ord]
@@ -17,13 +22,13 @@ module Z = struct
   let to_yojson z =
     `String (Z.to_string z)
 
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer Z.to_bits bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader Z.of_bits bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+  include Bin_prot.Utils.Make_binable
+      (struct
+        module Binable = Bin_string
+        type t = Z.t
+        let to_binable = Z.to_string
+        let of_binable = Z.of_string
+      end)
 end
 
 module Cstruct = struct
@@ -45,13 +50,13 @@ module Cstruct = struct
     | `String s -> Result.Ok (Cstruct.of_string s)
     | _ -> Result.Error "Cannot convert this json value to Cstruct.t"
 
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer Cstruct.to_string bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader Cstruct.of_string bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+  include Bin_prot.Utils.Make_binable
+      (struct
+        module Binable = Bin_string
+        type t = Cstruct.t
+        let to_binable = Cstruct.to_string
+        let of_binable s = Cstruct.of_string s
+      end)
 end
 
 module Asn_OID = struct
@@ -69,11 +74,11 @@ module Asn_OID = struct
   let to_yojson oid =
     `String (Asn.OID.to_string oid)
 
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer Asn.OID.to_string bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader Asn.OID.of_string bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-  let bin_t = Bin_prot.Type_class.{ reader = bin_reader_t; writer =  bin_writer_t}
+  include Bin_prot.Utils.Make_binable
+      (struct
+        module Binable = Bin_string
+        type t = Asn.OID.t
+        let to_binable = Asn.OID.to_string
+        let of_binable s = Asn.OID.of_string s
+      end)
 end

--- a/src/kp_derivable.mli
+++ b/src/kp_derivable.mli
@@ -1,0 +1,18 @@
+module Z : sig
+  type t = Z.t
+  [@@deriving bin_io,eq,ord,show,yojson]
+end
+
+module Cstruct : sig
+  type t = Cstruct.t
+  [@@deriving bin_io,eq,ord,show,yojson]
+end
+
+module Asn_OID : sig
+  type t = Asn.OID.t
+  [@@deriving eq,ord,show]
+
+  val to_yojson : t -> Yojson.Safe.json
+  val of_yojson : Yojson.Safe.json -> (t, string) Result.result
+  include Bin_prot.Binable.S with type t := t
+end

--- a/src/kp_ltpa.ml
+++ b/src/kp_ltpa.ml
@@ -1,27 +1,5 @@
 open Bin_prot.Std
 
-let pp_of_to_string to_string fmt x =
-  Format.pp_print_string fmt (to_string x)
-
-module Z = struct
-  include Z
-  let pp = pp_of_to_string to_string
-
-  let of_yojson = function
-    | `String s -> Result.Ok (Z.of_string s)
-    | _ -> Result.Error "Cannot convert this json value to Z.t"
-
-  let to_yojson z =
-    `String (Z.to_string z)
-
-  let bin_writer_t = Bin_prot.Type_class.cnv_writer to_bits bin_writer_string
-  let bin_reader_t = Bin_prot.Type_class.cnv_reader of_bits bin_reader_string
-  let bin_size_t = bin_writer_t.Bin_prot.Type_class.size
-  let bin_write_t = bin_writer_t.Bin_prot.Type_class.write
-  let bin_read_t = bin_reader_t.Bin_prot.Type_class.read
-  let __bin_read_t__ = bin_reader_t.Bin_prot.Type_class.vtag_read
-end
-
 (** Read a big-endian arbitrary length number *)
 let get_z_be cs off len =
   let r = ref Z.zero in
@@ -39,10 +17,10 @@ module RSA = struct
 
   module Private = struct
     type t = {
-      e: Z.t;
-      d: Z.t;
-      p: Z.t;
-      q: Z.t;
+      e: Kp_derivable.Z.t;
+      d: Kp_derivable.Z.t;
+      p: Kp_derivable.Z.t;
+      q: Kp_derivable.Z.t;
     }
     [@@deriving ord,eq,show,yojson,bin_io]
 
@@ -64,8 +42,8 @@ module RSA = struct
 
   module Public = struct
     type t = {
-      e: Z.t;
-      n: Z.t;
+      e: Kp_derivable.Z.t;
+      n: Kp_derivable.Z.t;
     }
     [@@deriving ord,eq,show,yojson,bin_io]
 


### PR DESCRIPTION
This is a fix for #28.

- It first makes the change easy by extracting a `Kp_derivable` private module that contains polyfills for `ppx_deriving` (`eq`, `ord`, `yojson`, and most importantly, `bin_io`).
- Then the custom functions are replaced by a functor application, ensuring that this is compatible with both `< v0.9.0` and `>= v0.9.0`.

Thanks! ✨ 