### PR TITLE
Add alternative DSA algorithm identifier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,20 +19,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2.0.0-beta3
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add key-parsers.dev . --no-action
-      - run: opam depext key-parsers --yes --with-doc --with-test
-      - run: opam install . --deps-only --with-doc --with-test
+      - run: opam depext key-parsers --yes --with-test
+      - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @all @runtest
   check-format:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use OCaml
         uses: ocaml/setup-ocaml@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+*2022-12-05*
+
+- Add alternative algorithm identifier for DSA keys
+- Improve reporting of unknown algorithm identifiers
+
 ## 1.4.0
 
 *2021-09-14*

--- a/lib/asn1.ml
+++ b/lib/asn1.ml
@@ -465,6 +465,8 @@ module Algorithm_identifier = struct
 
     let dsa_oid = Asn.OID.(base 1 2 <|| [840; 10040; 4; 1])
 
+    let dsa_oiw = Asn.OID.(base 1 3 <|| [14; 3; 2; 12])
+
     let ec_oid = Asn.OID.(base 1 2 <|| [840; 10045; 2; 1])
 
     let dh_oid = Asn.OID.(base 1 2 <|| [840; 113549; 1; 3; 1])
@@ -480,11 +482,18 @@ module Algorithm_identifier = struct
       | Dh
       | Unknown of Asn.OID.t
 
+    let to_string = function
+      | Dsa -> "DSA"
+      | Rsa -> "RSA"
+      | Ec -> "EC"
+      | Dh -> "DH"
+      | Unknown oid -> Format.asprintf "%a" Asn.OID.pp oid
+
     let grammar =
       let open Asn.S in
       let f = function
         | oid when oid = rsa_oid -> Rsa
-        | oid when oid = dsa_oid -> Dsa
+        | oid when oid = dsa_oid || oid = dsa_oiw -> Dsa
         | oid when oid = ec_oid || oid = ec_dh || oid = ec_mqv -> Ec
         | oid when oid = dh_oid -> Dh
         | oid -> Unknown oid
@@ -503,7 +512,9 @@ module Algorithm_identifier = struct
     let open Asn.S in
     let f = function
       | (Algo.Rsa, _) -> ()
-      | _ -> parse_error "Algorithm OID and parameters don't match"
+      | (algo, _) ->
+        parse_error "Algorithm %s and parameters don't match"
+          (Algo.to_string algo)
     in
     let g () = (Algo.Rsa, Some ()) in
     map f g
@@ -515,7 +526,9 @@ module Algorithm_identifier = struct
     let open Asn.S in
     let f = function
       | (Algo.Dsa, params) -> params
-      | (_, _) -> parse_error "Algorithm OID and parameters don't match"
+      | (algo, _) ->
+        parse_error "Algorithm %s and parameters don't match"
+          (Algo.to_string algo)
     in
     let g params = (Algo.Dsa, params) in
     map f g
@@ -527,7 +540,9 @@ module Algorithm_identifier = struct
     let open Asn.S in
     let f = function
       | (Algo.Ec, params) -> params
-      | (_, _) -> parse_error "Algorithm OID and parameters don't match"
+      | (algo, _) ->
+        parse_error "Algorithm %s and parameters don't match"
+          (Algo.to_string algo)
     in
     let g params = (Algo.Ec, params) in
     map f g
@@ -539,7 +554,9 @@ module Algorithm_identifier = struct
     let open Asn.S in
     let f = function
       | (Algo.Dh, params) -> params
-      | (_, _) -> parse_error "Algorithm OID and parameters don't match"
+      | (algo, _) ->
+        parse_error "Algorithm %s and parameters don't match"
+          (Algo.to_string algo)
     in
     let g params = (Algo.Dh, params) in
     map f g


### PR DESCRIPTION
Some X509 DSA public keys were producing a cryptic parse error:

```
X509 DSA key: Algorithm OID and parameters don't match
```

This was odd because the keys in question were accepted by `openssl dsa` and appeared identical when picked apart with `openssl asn1parse`.

It turns out that the parser was rejecting these keys because they used the OID `1.3.14.3.2.12` (see http://oidref.com/1.3.14.3.2.12) to specify the DSA algorithm instead of the usual `1.2.840.10040.4.1` (see http://oidref.com/1.2.840.10040.4.1).

This fixes that problem by adding the alternative OID to the parser. With this change, such keys will now be accepted.

This may be controversial, since [RFC 3279](https://www.rfc-editor.org/rfc/rfc3279#section-2.3.2) only mentions the usual OID:

```
      id-dsa OBJECT IDENTIFIER ::= {
           iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 1 }
```

If we want to stay 100% true to the RFC, then maybe we should reject this change.

However I would point out that we already deviate, in that the RFC says it's acceptable to leave out the DSA parameters `p`, `q` & `g`, but our parser insists that they be present. I'd also point out that OpenSSL accepts this OID, and the algorithm identified in both case is always just `dsaEncryption`.

I've also tweaked the behaviour when the algorithm identifier parser encounters an unknown OID. Previously it would produce a confusing parser error "Algorithm OID and parameters don't match". I've modified that minimally so that instead of "OID", it prints either the name of the algorithm (if the OID was known) or the actual OID if it was unknown. Hopefully this will make debugging similar errors easier in the future.